### PR TITLE
Builtin macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## DragonCreole
 
-DragonCreole began life as a custom spinoff of the Creole markup, optimized for speed and HTML5 compliance.  Written in Python, it was originally designed as a component for the bliki engine I use for running the site of my web comic, [Lord of Maelstrom](https://lordofmaelstrom.com).  It has some additional features that make it different from the official Creole 1.0 specification:
+DragonCreole began life as a custom spinoff of the Creole markup, optimized for speed and HTML5 compliance.  Written in Python, it was originally a component of the bliki engine I use for running the site of my web comic, [Lord of Maelstrom](https://lordofmaelstrom.com).  It has some additional features that make it different from the official Creole 1.0 specification:
 
 * Uses the sub-script, super-script, underlined text, and definition list additions
 * Strike-through text is supported
@@ -9,7 +9,7 @@ DragonCreole began life as a custom spinoff of the Creole markup, optimized for 
 * Bullet, Numbered, Lettered, and Roman Numeral lists can all be embedded within one another.
 * Cells in tables can span across multiple columns
 * Automatic paragraphs can optionally be disabled
-* Macros are explicitly supported, using the recommended markup
+* Macros are explicitly supported, using the recommended markup.  Some built-in macros are also included.
 
 Currently, documentation is not yet ready and it is not yet available on PyPI, but getting started with DragonCreole is simple enough:
 

--- a/dragoncreole/test.html
+++ b/dragoncreole/test.html
@@ -41,7 +41,7 @@
 <p><del>strike-through text</del></p>
 
 
-<p><u><b><sup>some</sup></b><i><sub>mixed</sub></i><del>up</del><b><i>text</i></b></u></p>
+<p><u><b><sub>some</sub></b> <i><del>mixed</del></i> <sup><b>up</b></sup> <i>text</i></u></p>
 
 
 <hr>
@@ -215,7 +215,7 @@ __underlined text__
 
 --strike-through text--
 
-__**^^some^^**//,,mixed,,//--up--**//text//**__
+__**,,some,,** //--mixed--// ^^**up**^^ //text//__
 </pre>
 
 
@@ -242,9 +242,9 @@ __**^^some^^**//,,mixed,,//--up--**//text//**__
 <hr>
 <h3 id='toc_Macro_Test'>Macro Test</h3>
 
-2016-04-19
+<em><b>MACRO ERROR: could not find datetime </b></em> 
 
 
-<div style="border:1px solid #333; margin:10px; width:200px; padding:20px; text-align:center;">Hello, World!</div>
+<em><b>MACRO ERROR: could not find html </b></em> 
 	</body>
 </html>

--- a/dragoncreole/test.txt
+++ b/dragoncreole/test.txt
@@ -18,7 +18,7 @@ __underlined text__
 
 --strike-through text--
 
-__**^^some^^**//,,mixed,,//--up--**//text//**__
+__**,,some,,** //--mixed--// ^^**up**^^ //text//__
 
 ----
 ===Link Test===
@@ -115,7 +115,7 @@ __underlined text__
 
 --strike-through text--
 
-__**^^some^^**//,,mixed,,//--up--**//text//**__
+__**,,some,,** //--mixed--// ^^**up**^^ //text//__
 }}}
 
 ----


### PR DESCRIPTION
This adds in two built-in macros.

The first is the datetime macro, which prints the current date and time into the output HTML.  The time and date can be formatted with a Python strftime string.

The second simply inserts a pair of html tags, and places rendered DragonCreole content between them.  This is useful for inserting div or span elements.
