### PR TITLE
Post-Processing

### DIFF
--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -402,6 +402,7 @@ class DragonCreole():
 		process = self.process
 		for key, item in sorted(self.postdata["footnoteIDs"].items(), key = lambda x: x[1]):
 			output += ["<li id='fn_{0}'>{1} <a href='#fnref_{0}'><sup>[ref]</sup></a></li>".format(key, process(fdata[key]))]
+		output += ["</ol>"]
 	
 		return "\n".join(output)
 		

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -316,6 +316,7 @@ class DragonCreole():
 	def handleHeading(self, line):
 		levels = 0
 		end = 0
+		hID = ""
 		for i, c in enumerate(line):
 			if(c in "=" and end == 0):
 				levels += 1
@@ -324,7 +325,14 @@ class DragonCreole():
 			else:
 				break
 		esc_string = escape(line[levels:end+1])
-		return "<h{0} id='toc_{2}'>{1}</h{0}>\n".format(str(levels), esc_string, esc_string.replace(" ", "_"))
+		if("^" in esc_string):
+			temp = esc_string.split("^", 1)
+			if(temp[1] != ""):
+				esc_string = temp[0]
+				hID = " id='{0}'".format(temp[1].replace(" ","_"))
+		if(hID==""):
+			hID = " id='{0}'".format(esc_string.replace(" ","_"))
+		return "<h{0}{2}>{1}</h{0}>\n".format(str(levels), esc_string, hID)
 	
 	'''
 	Parses links into html hyperlinks
@@ -344,7 +352,9 @@ class DragonCreole():
 		if(len(text)==2):
 			if(text[1] != ""):
 				name = self.process(text[1])
-		if(not ("://" in link or "www." in link)):
+		if(link == ""):
+			link = self.link_path + text[0].replace(" ","_")
+		elif(not ("://" in link or "www." in link)):
 			if(self.link_class_func != None):
 				LC = self.link_class_func(link)
 				if(LC != None):

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -378,7 +378,10 @@ class DragonCreole():
 			if(text[1] != ""):
 				name = self.process(text[1])
 		if(link == ""):
-			link = self.link_path + text[0].replace(" ","_")
+			if(text[0] == "/"):
+				link = "/"
+			else:
+				link = self.link_path + text[0].replace(" ","_")
 		elif(not ("://" in link or "www." in link)):
 			if(self.link_class_func != None):
 				LC = self.link_class_func(link)

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -350,7 +350,10 @@ class DragonCreole():
 		esc_string = escape(line[levels:end+1])
 		if("^" in esc_string):
 			temp = esc_string.split("^", 1)
-			if(temp[1] != ""):
+			if(temp[1] == ""):
+				esc_string = esc_string[:-1]
+				hID = ""
+			else:
 				esc_string = temp[0]
 				temp[1] = temp[1].replace(" ","_")
 				self.postdata["bookmarks"] += [(esc_string, temp[1],levels)]

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -109,7 +109,10 @@ class DragonCreole():
 	Renders a page to HTML
 	'''
 	def render(self, text, noMacros=None):
-		return "\n".join(self.renderSub(text, noMacros))
+		self.postdata = {}
+		ret = "\n".join(self.renderSub(text, noMacros))
+		self.postdata.clear()
+		return ret
 	
 	def macroRender(self, text, noMacros=None):
 		return "\n".join(self.renderSub(text, noMacros))

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -326,12 +326,8 @@ class DragonCreole():
 	def handleTOC(self, text):
 		index = text.find("$TOC")
 		lineEnd = text.find("\n",index)
-		output = []
-		
-		for i, bookmark in enumerate(self.postdata["bookmarks"]):
-			output += ["{0} [[#{1}|{2}]]".format("*" * bookmark[2], bookmark[1], bookmark[0])]
-		
-		return text[:index] + "<div id='_table_of_contents'>" + "\n".join(self.renderSub("\n".join(output))) + "</div>" + text[lineEnd:]
+		output = "\n".join(self.renderSub("\n".join(self.postdata["bookmarks"])))
+		return text[:index] + "<div id='_table_of_contents'>{0}</div>".format(output) + text[lineEnd:]
 	
 	'''
 	Handles the heading tag for text
@@ -356,10 +352,10 @@ class DragonCreole():
 			else:
 				esc_string = temp[0]
 				temp[1] = temp[1].replace(" ","_")
-				self.postdata["bookmarks"] += [(esc_string, temp[1],levels)]
+				self.postdata["bookmarks"] += ["{0} [[#{1}|{2}]]".format("*" * levels, temp[1], esc_string)]
 				hID = " id='{0}'".format(temp[1])
 		if(hID==None):
-			self.postdata["bookmarks"] += [(esc_string, esc_string.replace(" ","_"), levels)]
+			self.postdata["bookmarks"] += ["{0} [[{1}]]".format("*" * levels, esc_string)]
 			hID = " id='{0}'".format(esc_string.replace(" ","_"))
 		return "<h{0}{2}>{1}</h{0}>\n".format(str(levels), esc_string, hID)
 	

--- a/dragoncreole/dragoncreole.py
+++ b/dragoncreole/dragoncreole.py
@@ -109,8 +109,14 @@ class DragonCreole():
 	Renders a page to HTML
 	'''
 	def render(self, text, noMacros=None):
-		self.postdata = {}
+		self.postdata = {
+			"toc": False,
+			"bookmarks": []
+		}
+		
 		ret = "\n".join(self.renderSub(text, noMacros))
+		
+		
 		self.postdata.clear()
 		return ret
 	

--- a/dragoncreole/test.txt
+++ b/dragoncreole/test.txt
@@ -1,9 +1,12 @@
-=Heading 1=
-==Heading 2==
-===Heading 3===
-====Heading 4====
-=====Heading 5=====
-======Heading 6======
+=Heading 1^
+==Heading 2^
+===Heading 3^
+====Heading 4^
+=====Heading 5^
+======Heading 6^
+----
+===Table of Contents
+$TOC
 ----
 ===Format Test===
 **bold text**

--- a/dragoncreole/test.txt
+++ b/dragoncreole/test.txt
@@ -33,6 +33,9 @@ A named link to the [[/|Index Page]]
 
 A link to the [[#Macros|Macro Test]]
 
+This is a footnote[[^fntest]] and will link to a line of text on the bottom of the page.
+[[^fntest]]This is an example of a footnote!
+
 ----
 ===Image Test===
 A regular image:\\
@@ -143,3 +146,5 @@ The following text {{{is an inline preformat block}}} and will not be parsed.
 <<block "div" style="border:2px solid #333; margin:10px; width:200px; padding:0px; color:red; font-size:200%; text-align:center;">>
 Hello, World!
 <</block>>
+
+----

--- a/dragoncreole/test.txt
+++ b/dragoncreole/test.txt
@@ -28,6 +28,8 @@ A link to the [[index]]
 
 A named link to the [[/|Index Page]]
 
+A link to the [[#Macros|Macro Test]]
+
 ----
 ===Image Test===
 A regular image:\\
@@ -132,7 +134,7 @@ The following text {{{is an inline preformat block}}} and will not be parsed.
 ::**This is a justified double-indented paragraph.**  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.  This is a justified double-indented paragraph.
 ::::>**This is a quadruple-indented right-aligned paragraph.**  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.  This is a quadruple-indented right-aligned paragraph.
 ----
-===Macro Test
+===Macro Test^Macros
 <<datetime "%Y-%m-%d">> ~ <<datetime "%H:%M:%S">>
 
 <<block "div" style="border:2px solid #333; margin:10px; width:200px; padding:0px; color:red; font-size:200%; text-align:center;">>


### PR DESCRIPTION
This branch adds some post-processing capabilities to DragonCreole, by collecting checking for special markup during fragment rendering, and then after .renderSub() is finished, it will use that data to add some additional HTML content to the rendered HTML.
- **Link Parsing Fixed:** I fixed two bugs with link parsing.  One caused links to wind up blank if they were not formatted as a URL, and another was a failure to parse links that were only a forward-slash /
- **Table of Contents:** By adding a single line that only contains the string "$TOC", a table of contents will be inserted, with each entry being a hyperlink to each of the headings on a page.
- **Footnotes:** By inserting a ^ into the front of a link target, it will instead link to a footnote appended at the bottom of the page.  Text is provided by placing `[[^footnote_ID]]:` followed by the footnote's descriptive text on a separate line (almost) anywhere else in the document.  It will be omitted from fragment rendering, and be placed where it belongs at the bottom, along with a link to where the footnote was referenced in the HTML document.
